### PR TITLE
Fix documentation distribution plugin

### DIFF
--- a/subprojects/docs/src/docs/userguide/distributionPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/distributionPlugin.adoc
@@ -41,7 +41,7 @@ The plugin adds an extension named “`distributions`” of type api:org.gradle.
 
 You can run “`gradle distZip`” to package the main distribution as a ZIP, or “`gradle distTar`” to create a TAR file. To build both types of archives just run `gradle assembleDist`. The files will be created at “`__$buildDir__/distributions/__$project.name__-__$project.version__.__«ext»__`”.
 
-You can run “`gradle installDist`” to assemble the uncompressed distribution into “`__$buildDir__/install/__main__`”.
+You can run “`gradle installDist`” to assemble the uncompressed distribution into “`__$buildDir__/install/__$project.name__`”.
 
 [[sec:distribution_tasks]]
 === Tasks


### PR DESCRIPTION
installDist output is by default $buildDir/install/$project.name

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
